### PR TITLE
Add LCA calculation service and Kafka integration

### DIFF
--- a/scripts/kafkatotals.py
+++ b/scripts/kafkatotals.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+totals.py – quick-and-dirty helper to sum the environmental indicators
+in the export you pasted into ChatGPT.
+
+USAGE
+    python plugin-lca\scripts\kafkatotals.py kafkLLCAexport.json
+
+The script prints
+
+1. the grand total for each indicator across all rows
+2. an optional breakdown by material (mat_kbob)
+
+Requires only the Python 3 standard library.
+"""
+
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+METRICS = (
+    "gwp_relative", "gwp_absolute",
+    "penr_relative", "penr_absolute",
+    "ubp_relative", "ubp_absolute",
+)
+
+
+def main(json_path: Path) -> None:
+    # 1 – load the file --------------------------------------------------------
+    with json_path.open(encoding="utf-8") as f:
+        payload = json.load(f)
+
+    rows = payload.get("data", [])
+    if not rows:
+        sys.exit("No rows found under 'data' – nothing to do.")
+
+    # 2 – grand totals --------------------------------------------------------
+    grand = defaultdict(float)
+    for row in rows:
+        for m in METRICS:
+            grand[m] += row.get(m, 0.0)
+
+    print("=== GRAND TOTALS ===")
+    for m in METRICS:
+        print(f"{m:15}: {grand[m]:,.6f}")
+
+    # 3 – per-material breakdown (optional) -----------------------------------
+    per_material = defaultdict(lambda: defaultdict(float))
+    for row in rows:
+        mat = row.get("mat_kbob", "UNKNOWN")
+        for m in METRICS:
+            per_material[mat][m] += row.get(m, 0.0)
+
+    print("\n=== BREAKDOWN BY MATERIAL (mat_kbob) ===")
+    for mat, metrics in per_material.items():
+        print(f"\n{mat}")
+        for m in METRICS:
+            print(f"  {m:13}: {metrics[m]:,.6f}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit("Usage: python totals.py <path_to_json>")
+    main(Path(sys.argv[1]))

--- a/socket-backend/LcaCalculationService.ts
+++ b/socket-backend/LcaCalculationService.ts
@@ -1,0 +1,195 @@
+import {
+  LcaImpact,
+  MaterialInstanceResult,
+  LcaCalculationResult,
+  QtoElement,
+  KbobMaterial,
+} from "./types"; // Import types
+
+// --- Amortization Configuration ---
+// Using fixed lifetime for now
+const CURRENT_LIFETIME_YEARS = 45;
+const DEFAULT_AMORTIZATION_YEARS_FALLBACK = 50; // Fallback if needed later
+
+/* <<< FUTURE: Dynamic Amortization Data (keep commented or load dynamically) >>>
+const ebkpAmortizationPeriods = new Map<string, number>([
+    // ['C 1.1', 80],
+    // ... add mappings ...
+]);
+*/
+
+// Helper to normalize material names
+function normalizeMaterialName(name: string): string {
+  return name.replace(/\\s*\\(\\d+\\)\\s*$/, "");
+}
+
+export class LcaCalculationService {
+  /**
+   * Calculates absolute and relative impacts for all mapped materials in a project.
+   *
+   * @param qtoElements - Array of elements from the QTO database.
+   * @param materialMappings - Record mapping original material names/ids to KBOB IDs.
+   * @param kbobMaterials - Array of KBOB material data.
+   * @param ebf - Energiebezugsfläche (Energy Reference Area) for relative calculations.
+   * @returns An object containing the list of processed material instances and total impacts.
+   */
+  static calculateLcaResults(
+    qtoElements: QtoElement[],
+    materialMappings: Record<string, string>,
+    kbobMaterials: KbobMaterial[],
+    ebf: number | null
+  ): LcaCalculationResult {
+    const results: MaterialInstanceResult[] = [];
+    let totalGwp = 0;
+    let totalUbp = 0;
+    let totalPenr = 0;
+    let errors = 0;
+
+    const kbobMap = new Map(kbobMaterials.map((k) => [k.id, k]));
+    const effectiveEbf = ebf !== null && ebf > 0 ? ebf : null;
+
+    for (const qtoElement of qtoElements) {
+      const materialsInElement = qtoElement.materials || [];
+      const elementEbkcCode = qtoElement.properties?.ebkp_code || null;
+      const elementGlobalId =
+        qtoElement.global_id ||
+        qtoElement.ifc_id ||
+        qtoElement._id?.toString() || // Handle ObjectId
+        `unknown_element_${Math.random().toString(16).slice(2)}`; // Fallback
+
+      let sequence = 0;
+
+      if (Array.isArray(materialsInElement) && materialsInElement.length > 0) {
+        for (const material of materialsInElement) {
+          if (!material || typeof material.name !== "string") {
+            console.warn(
+              `[LCA Calc Elem: ${elementGlobalId}] Skipping invalid material entry: ${JSON.stringify(
+                material
+              )}`
+            );
+            errors++;
+            continue;
+          }
+
+          const normalizedQtoMatName = normalizeMaterialName(material.name);
+          let mappedKbobId: string | null = null;
+
+          // Find KBOB mapping (adapt based on how materialMappings keys are structured)
+          // This assumes keys in materialMappings might match normalized names
+          // Adjust if keys are element-specific IDs from the frontend.
+          mappedKbobId =
+            materialMappings[material.name] ||
+            materialMappings[normalizedQtoMatName] ||
+            null;
+          // If mappings use element-specific IDs, a different lookup approach is needed here.
+
+          const kbobMat = mappedKbobId ? kbobMap.get(mappedKbobId) : null;
+          const volume = parseFloat(material.volume?.toString() || "0");
+          const density = kbobMat?.density || 0;
+
+          let gwpAbs = 0,
+            ubpAbs = 0,
+            penrAbs = 0;
+          let gwpRel = 0,
+            ubpRel = 0,
+            penrRel = 0;
+          let amortizationYears = CURRENT_LIFETIME_YEARS; // Use fixed for now
+
+          if (
+            kbobMat &&
+            !isNaN(volume) &&
+            volume > 0 &&
+            !isNaN(density) &&
+            density > 0
+          ) {
+            const mass = volume * density;
+            gwpAbs = mass * (kbobMat.gwp || 0);
+            ubpAbs = mass * (kbobMat.ubp || 0);
+            penrAbs = mass * (kbobMat.penr || 0);
+
+            // --- Amortization Period Determination ---
+            // <<< CURRENT: Using fixed value >>>
+            amortizationYears = CURRENT_LIFETIME_YEARS;
+            // <<< FUTURE: Dynamic Lookup >>>
+            /*
+            amortizationYears = (elementEbkcCode ? ebkpAmortizationPeriods.get(elementEbkcCode) : null)
+                                ?? DEFAULT_AMORTIZATION_YEARS_FALLBACK;
+            */
+
+            // --- Relative Calculation ---
+            const divisor =
+              effectiveEbf !== null && effectiveEbf > 0 && amortizationYears > 0
+                ? amortizationYears * effectiveEbf
+                : null;
+
+            if (divisor !== null) {
+              gwpRel = gwpAbs / divisor;
+              ubpRel = ubpAbs / divisor;
+              penrRel = penrAbs / divisor;
+            } else {
+              // Relative values remain 0 if divisor is invalid
+              if (effectiveEbf === null)
+                console.warn(
+                  `[LCA Calc Elem: ${elementGlobalId}, Mat: ${material.name}] Cannot calculate relative values: Invalid EBF (${ebf}).`
+                );
+              // Add warning for amortizationYears if using dynamic lookup later
+            }
+
+            // Accumulate totals
+            totalGwp += gwpAbs;
+            totalUbp += ubpAbs;
+            totalPenr += penrAbs;
+          } else {
+            // Handle unmapped materials or materials with invalid data (volume/density)
+            // Impacts remain 0
+            if (!kbobMat && mappedKbobId)
+              console.warn(
+                `[LCA Calc Elem: ${elementGlobalId}, Mat: ${material.name}] KBOB data not found for mapped ID: ${mappedKbobId}`
+              );
+            else if (!mappedKbobId) {
+              /* console.log(`[LCA Calc Elem: ${elementGlobalId}, Mat: ${material.name}] No KBOB mapping found.`) */
+            } // Less verbose logging
+            else
+              console.warn(
+                `[LCA Calc Elem: ${elementGlobalId}, Mat: ${material.name}] Skipping calculation: Invalid volume (${volume}) or density (${density}).`
+              );
+            errors++; // Count as error if calculation couldn't be performed
+          }
+
+          results.push({
+            id: elementGlobalId,
+            sequence: sequence++,
+            material_name: material.name,
+            kbob_id: mappedKbobId,
+            kbob_name:
+              kbobMat?.nameDE ||
+              (mappedKbobId ? "KBOB Data Missing" : "Not Mapped"),
+            ebkp_code: elementEbkcCode,
+            amortization_years: amortizationYears,
+            gwp_absolute: gwpAbs,
+            ubp_absolute: ubpAbs,
+            penr_absolute: penrAbs,
+            gwp_relative: gwpRel,
+            ubp_relative: ubpRel,
+            penr_relative: penrRel,
+          });
+        } // end material loop
+      }
+    } // end element loop
+
+    console.log(
+      `[LCA Calc] Processed ${results.length} material instances. Errors/Skipped: ${errors}`
+    );
+
+    return {
+      materialInstances: results,
+      totalImpact: {
+        gwp: totalGwp,
+        ubp: totalUbp,
+        penr: totalPenr,
+      },
+      numberOfInstancesProcessed: results.length,
+      numberOfInstancesWithErrors: errors,
+    };
+  }
+}

--- a/socket-backend/types.ts
+++ b/socket-backend/types.ts
@@ -1,0 +1,101 @@
+// Define interfaces for LCA Calculation Service and Kafka data
+
+export interface LcaImpact {
+  gwp: number;
+  ubp: number;
+  penr: number;
+}
+
+// Input data for a material instance calculation
+export interface MaterialInstanceInput {
+  element_global_id: string;
+  material_name: string;
+  kbob_id: string | null;
+  kbob_material: any | null; // Consider a specific KbobMaterial type
+  volume: number;
+  ebkp_code: string | null;
+  sequence: number;
+}
+
+// Result data for a single material instance, including calculated impacts
+export interface MaterialInstanceResult {
+  id: string; // Corresponds to element_global_id
+  sequence: number;
+  material_name: string; // Original material name
+  kbob_id: string | null;
+  kbob_name: string; // Name from KBOB data
+  ebkp_code: string | null;
+  amortization_years: number; // The lifetime used for this instance
+  gwp_absolute: number;
+  ubp_absolute: number;
+  penr_absolute: number;
+  gwp_relative: number; // Calculated relative value (per m²·year)
+  ubp_relative: number; // Calculated relative value (per m²·year)
+  penr_relative: number; // Calculated relative value (per m²·year)
+}
+
+// Overall calculation result structure
+export interface LcaCalculationResult {
+  materialInstances: MaterialInstanceResult[];
+  totalImpact: LcaImpact;
+  numberOfInstancesProcessed: number;
+  numberOfInstancesWithErrors: number;
+}
+
+// QTO Element interface (ensure properties field is included)
+export interface QtoElement {
+  _id: any; // Using 'any' for flexibility with ObjectId/string
+  project_id: any;
+  global_id?: string;
+  ifc_id?: string;
+  properties?: { [key: string]: any };
+  materials?: {
+    name: string;
+    volume: string | number;
+    unit?: string;
+    fraction?: number;
+  }[];
+  // Add other necessary fields from your existing QtoElement definition
+  [key: string]: any; // Allow other properties
+}
+
+// KBOB Material interface
+export interface KbobMaterial {
+  id: string;
+  nameDE: string;
+  density?: number;
+  gwp?: number;
+  ubp?: number;
+  penr?: number;
+  [key: string]: any;
+}
+
+// Kafka data interface
+export interface LcaData {
+  id: string;
+  sequence: number;
+  mat_kbob: string;
+  gwp_relative: number;
+  gwp_absolute: number;
+  penr_relative: number;
+  penr_absolute: number;
+  ubp_relative: number;
+  ubp_absolute: number;
+}
+
+// Interface for the Kafka message metadata
+export interface KafkaMetadata {
+  project: string;
+  filename: string;
+  timestamp: string; // ISO string from fileProcessingTimestamp
+  fileId: string;
+}
+
+// Interface for the complete Kafka message structure
+export interface IfcFileData {
+  project: string;
+  filename: string;
+  timestamp: string;
+  fileId: string;
+  data?: LcaData[];
+}


### PR DESCRIPTION
- Introduced `LcaCalculationService` for calculating environmental impacts based on QTO elements and KBOB materials.
- Added `kafkatotals.py` script for summing environmental indicators from JSON exports.
- Updated `KafkaService` to handle pre-calculated LCA data and improved type safety with new interfaces.
- Enhanced server logic to utilize the new calculation service and send results to Kafka.
- Created new types for LCA calculations and Kafka data structures to ensure consistency across the application.