### PR TITLE
Use amortization period per eBKP element

### DIFF
--- a/socket-backend/data/amortizationData.ts
+++ b/socket-backend/data/amortizationData.ts
@@ -103,4 +103,4 @@ export const ebkpAmortizationPeriods: Map<string, number> = new Map([
   ["G04.04", 30],
 ]);
 
-export { DEFAULT_AMORTIZATION_YEARS } from "../utils/constants";
+

--- a/src/components/LCACalculator/ReviewDialog.tsx
+++ b/src/components/LCACalculator/ReviewDialog.tsx
@@ -27,9 +27,8 @@ import {
   LcaElement,
   MaterialImpact,
 } from "../../types/lca.types";
-import { BUILDING_LIFETIME_YEARS } from "../../utils/constants";
 import { LCACalculator } from "../../utils/lcaCalculator";
-import { DisplayMode } from "../../utils/lcaDisplayHelper";
+import { DisplayMode, LCADisplayHelper } from "../../utils/lcaDisplayHelper";
 import ElementImpactTable from "./ElementImpactTable";
 
 interface ReviewDialogProps {
@@ -86,12 +85,18 @@ const ReviewDialog: React.FC<ReviewDialogProps> = ({
     }).format(num);
   };
 
-  const getDisplayValue = (value: number | undefined): number | undefined => {
+  const getDisplayValue = (
+    value: number | undefined,
+    ebkpCode?: string
+  ): number | undefined => {
     if (value === undefined) return undefined;
-    if (displayMode === "relative" && ebfNumeric !== null && ebfNumeric > 0) {
-      return value / (BUILDING_LIFETIME_YEARS * ebfNumeric);
-    }
-    return value;
+    const { divisor, error } = LCADisplayHelper.getDivisorAndSuffix(
+      displayMode,
+      ebfNumeric,
+      ebkpCode
+    );
+    if (error) return undefined;
+    return value / divisor;
   };
 
   const getDecimalPrecision = (value: number | undefined): number => {
@@ -104,8 +109,11 @@ const ReviewDialog: React.FC<ReviewDialogProps> = ({
     return 0;
   };
 
-  const formatDisplayValue = (value: number | undefined): string => {
-    const displayValue = getDisplayValue(value);
+  const formatDisplayValue = (
+    value: number | undefined,
+    ebkpCode?: string
+  ): string => {
+    const displayValue = getDisplayValue(value, ebkpCode);
     if (displayValue === undefined) return "N/A";
     const decimals = getDecimalPrecision(displayValue);
     return formatNumber(displayValue, decimals);

--- a/src/data/amortizationData.ts
+++ b/src/data/amortizationData.ts
@@ -1,0 +1,28 @@
+// Mapping of eBKP-H codes to amortization periods in years
+export const ebkpAmortizationPeriods: Map<string, number> = new Map([
+  ["C01", 80],
+  ["C02.01", 80],
+  ["C02.02", 80],
+  ["C03", 80],
+  ["C04.01", 80],
+  ["C04.04", 80],
+  ["C04.05", 80],
+  ["C04.08", 80],
+  ["E01", 50],
+  ["E02.01", 50],
+  ["E02.02", 50],
+  ["E02.03", 50],
+  ["E02.04", 50],
+  ["E02.05", 50],
+  ["E03", 30],
+  ["F01.01", 40],
+  ["F01.02", 40],
+  ["F01.03", 40],
+  ["F02", 30],
+  ["G01", 50],
+  ["G02", 40],
+  ["G03", 40],
+  ["G04", 40],
+]);
+
+export { DEFAULT_AMORTIZATION_YEARS } from "../utils/constants";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,1 +1,1 @@
-export const BUILDING_LIFETIME_YEARS = 45;
+export const DEFAULT_AMORTIZATION_YEARS = 50;

--- a/src/utils/lcaCalculator.ts
+++ b/src/utils/lcaCalculator.ts
@@ -124,11 +124,13 @@ export class LCACalculator {
     materialDensities: Record<string, number> = {},
     lifetime?: number,
     displayMode: DisplayMode = "total",
-    ebf: number | null = null
+    ebf: number | null = null,
+    ebkpCode?: string
   ): string {
     const { divisor, suffix, error } = LCADisplayHelper.getDivisorAndSuffix(
       displayMode,
-      ebf
+      ebf,
+      ebkpCode
     );
 
     // Handle error state for relative mode with invalid EBF

--- a/src/utils/lcaDisplayHelper.ts
+++ b/src/utils/lcaDisplayHelper.ts
@@ -1,19 +1,23 @@
-import { BUILDING_LIFETIME_YEARS } from "./constants";
+import { ebkpAmortizationPeriods, DEFAULT_AMORTIZATION_YEARS } from "../data/amortizationData";
 
 // Define display mode type
 export type DisplayMode = "total" | "relative";
 
 export class LCADisplayHelper {
   /**
-   * Gets the appropriate divisor and suffix for formatting based on display mode and EBF
+   * Gets the appropriate divisor and suffix for formatting based on display mode, EBF and optional eBKP code
    */
   static getDivisorAndSuffix(
     displayMode: DisplayMode,
-    ebf: number | null
+    ebf: number | null,
+    ebkpCode?: string
   ): { divisor: number; suffix: string; error?: string } {
     if (displayMode === "relative") {
       if (ebf !== null && ebf > 0) {
-        return { divisor: BUILDING_LIFETIME_YEARS * ebf, suffix: "/m²·Jahr" }; // Use middot for clarity
+        const years = ebkpCode
+          ? ebkpAmortizationPeriods.get(ebkpCode) ?? DEFAULT_AMORTIZATION_YEARS
+          : DEFAULT_AMORTIZATION_YEARS;
+        return { divisor: years * ebf, suffix: "/m²·Jahr" };
       } else {
         // Return error state if relative mode selected but EBF invalid
         return { divisor: 1, suffix: "", error: "N/A (EBF fehlt)" };


### PR DESCRIPTION
## Summary
- replace fixed BUILDING_LIFETIME_YEARS with DEFAULT_AMORTIZATION_YEARS
- add amortization mapping for eBKP codes
- account for element‐specific amortization in `LCADisplayHelper`
- pass eBKP code through ElementImpactTable and ReviewDialog

## Testing
- `npm run lint` *(fails: prop-types errors)*
- `npm run build:test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Impact metrics now use dynamic amortization periods based on element codes, providing more accurate calculations and display values.
- **Refactor**
  - Updated calculation and formatting logic for impact values to use a centralized helper and new data source for amortization periods.
  - Enhanced amortization period determination with special handling for specific element descriptions.
- **Chores**
  - Replaced the building lifetime constant with a default amortization period and centralized amortization data for easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->