### PR TITLE
Add excavation material and handle volume units

### DIFF
--- a/src/data/indicatorsKBOB_v6.json
+++ b/src/data/indicatorsKBOB_v6.json
@@ -5306,4 +5306,15 @@
       "subType": "04"
     }
   }
-}]
+},
+{
+  "_id": { "$oid": "014973935843e4fa4cb545d4" },
+  "KBOB_ID": "B06.01",
+  "Name": "Aushub",
+  "GWP": 4.0,
+  "UBP": 10,
+  "PENRE": 1.5,
+  "unit": "m³",
+  "uuid": { "$binary": { "base64": "oEd40LPoZbnXMGKlYcgz7Q==", "subType": "04" } }
+}
+]

--- a/src/types/lca.types.ts
+++ b/src/types/lca.types.ts
@@ -68,7 +68,7 @@ export interface UnmodelledMaterial {
 export interface KbobMaterial {
   id: string;
   nameDE: string;
-  density: number;
+  density?: number;
   densityRange?: {
     min: number;
     max: number;


### PR DESCRIPTION
## Summary
- extend KBOB dataset with `Aushub` (excavation) entry
- treat materials with unit `m³` as volume based in impact calculator
- support optional density in `KbobMaterial`

## Testing
- `npm run lint` *(fails: react lint issues)*
- `npm run build:test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new indicator entry "Aushub" with associated environmental impact values to the indicators list.

- **Improvements**
  - Enhanced impact calculation logic to better handle volume-based materials, ensuring accurate results for materials measured in cubic meters.
  - The material density field is now optional, allowing more flexibility when entering material data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->