### PR TITLE
feat: enhance LCACalculator to support user-edited quantities

### DIFF
--- a/src/components/LCACalculator/ElementImpactTable.tsx
+++ b/src/components/LCACalculator/ElementImpactTable.tsx
@@ -365,7 +365,8 @@ const ElementImpactTable: React.FC<ElementImpactTableProps> = ({
 
         const group = groups.get(key)!;
         group.elementCount += 1;
-        group.totalQuantity += element.quantity ?? 0;
+        const quantityToAdd = Number.isFinite(element.quantity) ? element.quantity : 0;
+        group.totalQuantity += quantityToAdd;
         group.totalImpact.gwp += element.impact?.gwp ?? 0;
         group.totalImpact.ubp += element.impact?.ubp ?? 0;
         group.totalImpact.penr += element.impact?.penr ?? 0;


### PR DESCRIPTION
- Updated RawElement interface to allow quantity as a number or a QTO object.
- Implemented logic to extract and scale material volumes based on user-edited quantities.
- Improved handling of original material volumes and total volume calculations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for QTO-edited quantity objects enabling proportional material volume scaling based on user modifications.

* **Bug Fixes**
  * Improved material calculation consistency and maintained backward compatibility with legacy numeric quantity formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->